### PR TITLE
add dev branch support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,14 @@
+### NEW
+
+- Installer can install ~5.0.x-dev and ~4.6.x-dev versions.
+- Shortcuts for version constraints:
+    - _main_ or _5.0_ ==> ~5.0.x-dev
+    - _4.6_ => ~4.6.x-dev
+    - _LTS_, _lts_, _latest_ => latest v4.6.xx 
+
 # ibexa-ddev-toolkit
 
 Kick starter to create a clean Ibexa DXP project using ddev.
-It's perfectly what I need for my daily work - and will rarely be changed/improved in the future.  
 
 ## Install ddev:
 --> https://ddev.readthedocs.io/en/latest/users/install/ddev-installation/
@@ -30,6 +37,8 @@ It's perfectly what I need for my daily work - and will rarely be changed/improv
 │ ../ddev-dxp-installer.sh add_solr                                   │
 │                                                                     │
 └─────────────────────────────────────────────────────────────────────┘
+
+
 
 # default config
 release: ~4.6       # latest 4.x

--- a/ddev-dxp-installer.sh
+++ b/ddev-dxp-installer.sh
@@ -216,13 +216,44 @@ if [[ "$1" = "content" ]] &&  [[ "$release" =~ .*"4.6".* ]]; then
   flavor="headless"
 fi
 
-ddev composer create -y ibexa/$flavor-skeleton:$release --no-install
+# dev versions
+devversion=0
 
-if [[ "$php_version" = "8.3" && "$release" =~ .*"4.6".*  ]]
+case $release in
+# 4.6 branch
+4.6 )
+  release=~4.6.x-dev
+  ;;
+# main / 5.0 branch
+5.0 | main )
+  release=~5.0.x-dev
+  ;;
+latest | lts | LTS )
+  release=~4.6.0
+  ;;
+esac
+
+if [[ "$release" =~ .*"-dev" ]]
   then
-    ddev composer install
+  devversion=1
+fi
+
+
+if [ "$devversion" = 1  ]
+  then
+    ddev composer create ibexa/website-skeleton:$release
+    ddev composer config repositories.ibexa composer https://updates.ibexa.co
+    ddev composer require ibexa/$flavor:$release -W --no-scripts --no-interaction
+    ddev composer recipes:install ibexa/$flavor --force --reset # --no-interaction
+    
   else
-    ddev composer update
+    ddev composer create -y ibexa/$flavor-skeleton:$release --no-install
+    if [[ "$php_version" = "8.3" && "$release" =~ .*"4.6".*  ]]
+      then
+        ddev composer install
+      else
+        ddev composer update
+    fi
 fi
 
 if [ "$require_profiler" = "1" ]


### PR DESCRIPTION
- Installer can install ~5.0.x-dev and ~4.6.x-dev versions.
- Shortcuts for version contstraints:
    - _main_ or _5.0_ ==> ~5.0.x-dev
    - _4.6_ => ~4.6.x-dev
    - _LTS_, _lts_, _latest_ => latest v4.6.xx 